### PR TITLE
Pkcs7 pr4

### DIFF
--- a/include/mbedtls/check_config.h
+++ b/include/mbedtls/check_config.h
@@ -764,6 +764,12 @@
 #error "MBEDTLS_HAVE_INT32/MBEDTLS_HAVE_INT64 and MBEDTLS_HAVE_ASM cannot be defined simultaneously"
 #endif /* (MBEDTLS_HAVE_INT32 || MBEDTLS_HAVE_INT64) && MBEDTLS_HAVE_ASM */
 
+#if ( ( defined(MBEDTLS_PKCS7_C) ) && ( !defined(MBEDTLS_ASN1_PARSE_C) ) && \
+    ( !defined(MBEDTLS_OID_C) ) && ( !defined(MBEDTLD_PK_PARSE_C) ) && \
+    ( !defined(MBEDTLS_X509_CRT_PARSE_C) ) && ( !defined(MBEDTLS_BIGNUM_C) ) )
+#error  "MBEDTLS_PKCS7_C is defined, but not all prerequisites"
+#endif
+
 /*
  * Avoid warning from -pedantic. This is a convenient place for this
  * workaround since this is included by every single file before the

--- a/include/mbedtls/config.h
+++ b/include/mbedtls/config.h
@@ -2720,6 +2720,21 @@
 #define MBEDTLS_PKCS5_C
 
 /**
+ * \def MBEDTLS_PKCS7_C
+ *
+ * Enable PKCS7 core for using PKCS7 formatted signatures.
+ * RFC Link - https://tools.ietf.org/html/rfc2315
+ *
+ * Module:  library/pkcs7.c
+ *
+ * Requires: MBEDTLS_ASN1_PARSE_C, MBEDTLS_OID_C, MBEDTLS_PK_PARSE_C,
+ *         MBEDTLS_X509_CRT_PARSE_C MBEDTLS_X509_CRL_PARSE_C, MBEDTLS_ERROR_C
+ *
+ * This module is required for the PKCS7 parsing modules.
+ */
+#define MBEDTLS_PKCS7_C
+
+/**
  * \def MBEDTLS_PKCS11_C
  *
  * Enable wrapper for PKCS#11 smartcard support.

--- a/include/mbedtls/error.h
+++ b/include/mbedtls/error.h
@@ -129,6 +129,7 @@
  * CIPHER    6   8
  * SSL       6   23 (Started from top)
  * SSL       7   32
+ * PKCS7     5   12 (Started from 0x5300)
  *
  * Module dependent error code (5 bits 0x.00.-0x.F8.)
  */

--- a/include/mbedtls/oid.h
+++ b/include/mbedtls/oid.h
@@ -215,6 +215,7 @@
 #define MBEDTLS_OID_PKCS                MBEDTLS_OID_RSA_COMPANY "\x01" /**< pkcs OBJECT IDENTIFIER ::= { iso(1) member-body(2) us(840) rsadsi(113549) 1 } */
 #define MBEDTLS_OID_PKCS1               MBEDTLS_OID_PKCS "\x01" /**< pkcs-1 OBJECT IDENTIFIER ::= { iso(1) member-body(2) us(840) rsadsi(113549) pkcs(1) 1 } */
 #define MBEDTLS_OID_PKCS5               MBEDTLS_OID_PKCS "\x05" /**< pkcs-5 OBJECT IDENTIFIER ::= { iso(1) member-body(2) us(840) rsadsi(113549) pkcs(1) 5 } */
+#define MBEDTLS_OID_PKCS7               MBEDTLS_OID_PKCS "\x07" /**< pkcs-7 OBJECT IDENTIFIER ::= { iso(1) member-body(2) us(840) rsadsi(113549) pkcs(1) 7 } */
 #define MBEDTLS_OID_PKCS9               MBEDTLS_OID_PKCS "\x09" /**< pkcs-9 OBJECT IDENTIFIER ::= { iso(1) member-body(2) us(840) rsadsi(113549) pkcs(1) 9 } */
 #define MBEDTLS_OID_PKCS12              MBEDTLS_OID_PKCS "\x0c" /**< pkcs-12 OBJECT IDENTIFIER ::= { iso(1) member-body(2) us(840) rsadsi(113549) pkcs(1) 12 } */
 
@@ -298,6 +299,16 @@
 #define MBEDTLS_OID_PKCS5_PBE_MD5_RC2_CBC       MBEDTLS_OID_PKCS5 "\x06" /**< pbeWithMD5AndRC2-CBC OBJECT IDENTIFIER ::= {pkcs-5 6} */
 #define MBEDTLS_OID_PKCS5_PBE_SHA1_DES_CBC      MBEDTLS_OID_PKCS5 "\x0a" /**< pbeWithSHA1AndDES-CBC OBJECT IDENTIFIER ::= {pkcs-5 10} */
 #define MBEDTLS_OID_PKCS5_PBE_SHA1_RC2_CBC      MBEDTLS_OID_PKCS5 "\x0b" /**< pbeWithSHA1AndRC2-CBC OBJECT IDENTIFIER ::= {pkcs-5 11} */
+
+/*
+ * PKCS#7 OIDs
+ */
+#define MBEDTLS_OID_PKCS7_DATA                        MBEDTLS_OID_PKCS7 "\x01" /**< Content type is Data OBJECT IDENTIFIER ::= {pkcs-7 1} */
+#define MBEDTLS_OID_PKCS7_SIGNED_DATA                 MBEDTLS_OID_PKCS7 "\x02" /**< Content type is Signed Data OBJECT IDENTIFIER ::= {pkcs-7 2} */
+#define MBEDTLS_OID_PKCS7_ENVELOPED_DATA              MBEDTLS_OID_PKCS7 "\x03" /**< Content type is Enveloped Data OBJECT IDENTIFIER ::= {pkcs-7 3} */
+#define MBEDTLS_OID_PKCS7_SIGNED_AND_ENVELOPED_DATA   MBEDTLS_OID_PKCS7 "\x04" /**< Content type is Signed and Enveloped Data OBJECT IDENTIFIER ::= {pkcs-7 4} */
+#define MBEDTLS_OID_PKCS7_DIGESTED_DATA               MBEDTLS_OID_PKCS7 "\x05" /**< Content type is Digested Data OBJECT IDENTIFIER ::= {pkcs-7 5} */
+#define MBEDTLS_OID_PKCS7_ENCRYPTED_DATA              MBEDTLS_OID_PKCS7 "\x06" /**< Content type is Encrypted Data OBJECT IDENTIFIER ::= {pkcs-7 6} */
 
 /*
  * PKCS#8 OIDs

--- a/include/mbedtls/pkcs7.h
+++ b/include/mbedtls/pkcs7.h
@@ -1,0 +1,213 @@
+/**
+ * \file pkcs7.h
+ *
+ * \brief PKCS7 generic defines and structures
+ */
+/*
+ *  Copyright (C) 2019,  IBM Corp, All Rights Reserved
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"); you may
+ *  not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *  This file is part of mbed TLS (https://tls.mbed.org)
+ */
+#ifndef MBEDTLS_PKCS7_H
+#define MBEDTLS_PKCS7_H
+
+#if !defined(MBEDTLS_CONFIG_FILE)
+#include "config.h"
+#else
+#include MBEDTLS_CONFIG_FILE
+#endif
+
+#include "asn1.h"
+#include "x509.h"
+#include "x509_crt.h"
+
+/**
+ * \name PKCS7 Module Error codes
+ * \{
+ */
+#define MBEDTLS_ERR_PKCS7_INVALID_FORMAT                   -0x5300  /**< The format is invalid, e.g. different type expected. */
+#define MBEDTLS_ERR_PKCS7_FEATURE_UNAVAILABLE              -0x53F0  /**< Unavailable feature, e.g. anything other than signed data. */
+#define MBEDTLS_ERR_PKCS7_INVALID_VERSION                  -0x5400  /**< The PKCS7 version element is invalid or cannot be parsed. */
+#define MBEDTLS_ERR_PKCS7_INVALID_CONTENT_INFO             -0x54F0  /**< The PKCS7 content info invalid or cannot be parsed. */
+#define MBEDTLS_ERR_PKCS7_INVALID_ALG                      -0x5500  /**< The algorithm tag or value is invalid or cannot be parsed. */
+#define MBEDTLS_ERR_PKCS7_INVALID_CERT                     -0x55F0  /**< The certificate tag or value is invalid or cannot be parsed. */
+#define MBEDTLS_ERR_PKCS7_INVALID_SIGNATURE                -0x5600  /**< Error parsing the signature */
+#define MBEDTLS_ERR_PKCS7_INVALID_SIGNER_INFO              -0x56F0  /**< Error parsing the signer's info */
+#define MBEDTLS_ERR_PKCS7_BAD_INPUT_DATA                   -0x5700  /**< Input invalid. */
+#define MBEDTLS_ERR_PKCS7_ALLOC_FAILED                     -0x57F0  /**< Allocation of memory failed. */
+#define MBEDTLS_ERR_PKCS7_FILE_IO_ERROR                    -0x5800  /**< File Read/Write Error */
+#define MBEDTLS_ERR_PKCS7_VERIFY_FAIL                      -0x58F0  /**< Verification Failed */
+/* \} name */
+
+/**
+ * \name PKCS7 Supported Version
+ * \{
+ */
+#define MBEDTLS_PKCS7_SUPPORTED_VERSION                           0x01
+/* \} name */
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * Type-length-value structure that allows for ASN1 using DER.
+ */
+typedef mbedtls_asn1_buf mbedtls_pkcs7_buf;
+
+/**
+ * Container for ASN1 named information objects.
+ * It allows for Relative Distinguished Names (e.g. cn=localhost,ou=code,etc.).
+ */
+typedef mbedtls_asn1_named_data mbedtls_pkcs7_name;
+
+/**
+ * Container for a sequence of ASN.1 items
+ */
+typedef mbedtls_asn1_sequence mbedtls_pkcs7_sequence;
+
+/**
+ * Structure holding PKCS7 signer info
+ */
+typedef struct mbedtls_pkcs7_signer_info
+{
+    int version;
+    mbedtls_x509_buf serial;
+    mbedtls_x509_name issuer;
+    mbedtls_x509_buf issuer_raw;
+    mbedtls_x509_buf alg_identifier;
+    mbedtls_x509_buf sig_alg_identifier;
+    mbedtls_x509_buf sig;
+    struct mbedtls_pkcs7_signer_info *next;
+}
+mbedtls_pkcs7_signer_info;
+
+/**
+ * Structure holding attached data as part of PKCS7 signed data format
+ */
+typedef struct mbedtls_pkcs7_data
+{
+    mbedtls_pkcs7_buf oid;
+    mbedtls_pkcs7_buf data;
+}
+mbedtls_pkcs7_data;
+
+/**
+ * Structure holding the signed data section
+ */
+typedef struct mbedtls_pkcs7_signed_data
+{
+    int version;
+    mbedtls_pkcs7_buf digest_alg_identifiers;
+    struct mbedtls_pkcs7_data content;
+    mbedtls_x509_crt certs;
+    mbedtls_x509_crl crl;
+    struct mbedtls_pkcs7_signer_info signers;
+}
+mbedtls_pkcs7_signed_data;
+
+/**
+ * Structure holding PKCS7 structure, only signed data for now
+ */
+typedef struct mbedtls_pkcs7
+{
+    mbedtls_pkcs7_buf content_type_oid;
+    struct mbedtls_pkcs7_signed_data signed_data;
+}
+mbedtls_pkcs7;
+
+/**
+ * \brief          Initialize pkcs7 structure.
+ *
+ * \param pkcs7      pkcs7 structure.
+ */
+void mbedtls_pkcs7_init( mbedtls_pkcs7 *pkcs7 );
+
+/**
+ * \brief          Parse a single DER formatted pkcs7 content.
+ *
+ * \param buf      The buffer holding the DER encoded pkcs7.
+ * \param buflen   The size in Bytes of \p buf.
+ *
+ * \note           This function makes an internal copy of the PKCS7 buffer
+ *                 \p buf. In particular, \p buf may be destroyed or reused
+ *                 after this call returns.
+ *
+ * \return         \c 0, if successful.
+ * \return         A negative error code on failure.
+ */
+int mbedtls_pkcs7_parse_der( const unsigned char *buf, const int buflen,
+                             mbedtls_pkcs7 *pkcs7 );
+
+/**
+ * \brief          Verification of PKCS7 signature.
+ *
+ * \param pkcs7    PKCS7 structure containing signature.
+ * \param cert     Certificate containing key to verify signature.
+ * \param data     Plain data on which signature has to be verified.
+ * \param datalen  Length of the data.
+ *
+ * \note           This function internally calculates the hash on the supplied
+ *                 plain data for signature verification.
+ *
+ * \return         A negative error code on failure.
+ */
+int mbedtls_pkcs7_signed_data_verify( mbedtls_pkcs7 *pkcs7,
+                                      mbedtls_x509_crt *cert,
+                                      const unsigned char *data,
+                                      size_t datalen );
+
+/**
+ * \brief          Verification of PKCS7 signature.
+ *
+ * \param pkcs7    PKCS7 structure containing signature.
+ * \param cert     Certificate containing key to verify signature.
+ * \param hash     Hash of the plain data on which signature has to be verified.
+ * \param hashlen  Length of the hash.
+ *
+ * \note           This function is different from mbedtls_pkcs7_signed_data_verify()
+ *                 in a way that it directly recieves the hash of the data.
+ *
+ * \return         A negative error code on failure.
+ */
+int mbedtls_pkcs7_signed_hash_verify( mbedtls_pkcs7 *pkcs7,
+                                      mbedtls_x509_crt *cert,
+                                      const unsigned char *hash, int hashlen);
+
+/**
+ * \brief          Reads the PKCS7 data from the file in a buffer.
+ *
+ * \param path     Path of the file.
+ * \param buf      Buffer to store the PKCS7 contents from the file.
+ * \param n        Size of the buffer (the contents read from the file).
+ *
+ * \return         A negative error code on failure.
+ */
+int mbedtls_pkcs7_load_file( const char *path, unsigned char **buf, size_t *n );
+
+/**
+ * \brief          Unallocate all PKCS7 data and zeroize the memory.
+ *                 It doesn't free pkcs7 itself. It should be done by the caller.
+ *
+ * \param pkcs7    PKCS7 structure to free.
+ */
+void mbedtls_pkcs7_free(  mbedtls_pkcs7 *pkcs7 );
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* pkcs7.h */

--- a/include/mbedtls/pkcs7.h
+++ b/include/mbedtls/pkcs7.h
@@ -80,6 +80,20 @@ typedef mbedtls_asn1_named_data mbedtls_pkcs7_name;
 typedef mbedtls_asn1_sequence mbedtls_pkcs7_sequence;
 
 /**
+ * PKCS7 types
+ */
+typedef enum {
+    MBEDTLS_PKCS7_NONE=0,
+    MBEDTLS_PKCS7_DATA,
+    MBEDTLS_PKCS7_SIGNED_DATA,
+    MBEDTLS_PKCS7_ENVELOPED_DATA,
+    MBEDTLS_PKCS7_SIGNED_AND_ENVELOPED_DAYA,
+    MBEDTLS_PKCS7_DIGESTED_DATA,
+    MBEDTLS_PKCS7_ENCRYPTED_DATA,
+}
+mbedtls_pkcs7_type;
+
+/**
  * Structure holding PKCS7 signer info
  */
 typedef struct mbedtls_pkcs7_signer_info

--- a/library/Makefile
+++ b/library/Makefile
@@ -88,7 +88,8 @@ OBJS_CRYPTO=	aes.o		aesni.o		arc4.o		\
 
 OBJS_X509=	certs.o		pkcs11.o	x509.o		\
 		x509_create.o	x509_crl.o	x509_crt.o	\
-		x509_csr.o	x509write_crt.o	x509write_csr.o
+		x509_csr.o	x509write_crt.o	x509write_csr.o \
+		pkcs7.o
 
 OBJS_TLS=	debug.o		net_sockets.o		\
 		ssl_cache.o	ssl_ciphersuites.o	\

--- a/library/error.c
+++ b/library/error.c
@@ -194,6 +194,10 @@
 #include "mbedtls/pkcs5.h"
 #endif
 
+#if defined(MBEDTLS_PKCS7_C)
+#include "mbedtls/pkcs7.h"
+#endif
+
 #if defined(MBEDTLS_PLATFORM_C)
 #include "mbedtls/platform.h"
 #endif
@@ -414,6 +418,33 @@ void mbedtls_strerror( int ret, char *buf, size_t buflen )
         if( use_ret == -(MBEDTLS_ERR_PKCS5_PASSWORD_MISMATCH) )
             mbedtls_snprintf( buf, buflen, "PKCS5 - Given private key password does not allow for correct decryption" );
 #endif /* MBEDTLS_PKCS5_C */
+
+#if defined(MBEDTLS_PKCS7_C)
+        if( use_ret == -(MBEDTLS_ERR_PKCS7_INVALID_FORMAT) )
+            mbedtls_snprintf( buf, buflen, "PKCS7 - The format is invalid, e.g. different type expected" );
+        if( use_ret == -(MBEDTLS_ERR_PKCS7_FEATURE_UNAVAILABLE) )
+            mbedtls_snprintf( buf, buflen, "PKCS7 - Unavailable feature, e.g. anything other than signed data" );
+        if( use_ret == -(MBEDTLS_ERR_PKCS7_INVALID_VERSION) )
+            mbedtls_snprintf( buf, buflen, "PKCS7 - The PKCS7 version element is invalid or cannot be parsed" );
+        if( use_ret == -(MBEDTLS_ERR_PKCS7_INVALID_CONTENT_INFO) )
+            mbedtls_snprintf( buf, buflen, "PKCS7 - The PKCS7 content info invalid or cannot be parsed" );
+        if( use_ret == -(MBEDTLS_ERR_PKCS7_INVALID_ALG) )
+            mbedtls_snprintf( buf, buflen, "PKCS7 - The algorithm tag or value is invalid or cannot be parsed" );
+        if( use_ret == -(MBEDTLS_ERR_PKCS7_INVALID_CERT) )
+            mbedtls_snprintf( buf, buflen, "PKCS7 - The certificate tag or value is invalid or cannot be parsed" );
+        if( use_ret == -(MBEDTLS_ERR_PKCS7_INVALID_SIGNATURE) )
+            mbedtls_snprintf( buf, buflen, "PKCS7 - Error parsing the signature" );
+        if( use_ret == -(MBEDTLS_ERR_PKCS7_INVALID_SIGNER_INFO) )
+            mbedtls_snprintf( buf, buflen, "PKCS7 - Error parsing the signer's info" );
+        if( use_ret == -(MBEDTLS_ERR_PKCS7_BAD_INPUT_DATA) )
+            mbedtls_snprintf( buf, buflen, "PKCS7 - Input invalid" );
+        if( use_ret == -(MBEDTLS_ERR_PKCS7_ALLOC_FAILED) )
+            mbedtls_snprintf( buf, buflen, "PKCS7 - Allocation of memory failed" );
+        if( use_ret == -(MBEDTLS_ERR_PKCS7_FILE_IO_ERROR) )
+            mbedtls_snprintf( buf, buflen, "PKCS7 - File Read/Write Error" );
+        if( use_ret == -(MBEDTLS_ERR_PKCS7_VERIFY_FAIL) )
+            mbedtls_snprintf( buf, buflen, "PKCS7 - Verification Failed" );
+#endif /* MBEDTLS_PKCS7_C */
 
 #if defined(MBEDTLS_RSA_C)
         if( use_ret == -(MBEDTLS_ERR_RSA_BAD_INPUT_DATA) )

--- a/library/pkcs7.c
+++ b/library/pkcs7.c
@@ -1,0 +1,574 @@
+/* Copyright 2019 IBM Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#if !defined(MBEDTLS_CONFIG_FILE)
+#include "mbedtls/config.h"
+#else
+#include MBEDTLS_CONFIG_FILE
+#endif
+#if defined(MBEDTLS_PKCS7_C)
+
+#include "mbedtls/x509.h"
+#include "mbedtls/asn1.h"
+#include "mbedtls/pkcs7.h"
+#include "mbedtls/x509_crt.h"
+#include "mbedtls/x509_crl.h"
+#include "mbedtls/oid.h"
+
+#include <stdlib.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+#if defined(MBEDTLS_PLATFORM_C)
+#include "mbedtls/platform.h"
+#include "mbedtls/platform_util.h"
+#else
+#include <stdio.h>
+#include <stdlib.h>
+#define mbedtls_free      free
+#define mbedtls_calloc    calloc
+#define mbedtls_printf    printf
+#define mbedtls_snprintf  snprintf
+#endif
+
+#if defined(MBEDTLS_HAVE_TIME)
+#include "mbedtls/platform_time.h"
+#endif
+#if defined(MBEDTLS_HAVE_TIME_DATE)
+#include <time.h>
+#endif
+
+/*
+ * Load all data from a file into a given buffer.
+ *
+ * The file is expected to contain DER encoded data.
+ * A terminating null byte is always appended.
+ */
+int mbedtls_pkcs7_load_file( const char *path, unsigned char **buf, size_t *n )
+{
+    FILE *file;
+
+    if( ( file = fopen( path, "rb" ) ) == NULL )
+        return( MBEDTLS_ERR_PKCS7_FILE_IO_ERROR );
+
+    fseek( file, 0, SEEK_END );
+    *n = (size_t) ftell( file );
+    fseek( file, 0, SEEK_SET );
+
+    *buf = mbedtls_calloc( 1, *n + 1 );
+    if( *buf == NULL )
+        return( MBEDTLS_ERR_PKCS7_ALLOC_FAILED );
+
+    if( fread( *buf, 1, *n, file ) != *n )
+    {
+        fclose( file );
+
+        mbedtls_platform_zeroize( *buf, *n + 1 );
+        mbedtls_free( *buf );
+
+        return( MBEDTLS_ERR_PKCS7_FILE_IO_ERROR );
+    }
+
+    fclose( file );
+
+    (*buf)[*n] = '\0';
+
+    return( 0 );
+}
+
+/**
+ * Initializes the pkcs7 structure.
+ */
+void mbedtls_pkcs7_init( mbedtls_pkcs7 *pkcs7 )
+{
+    memset( pkcs7, 0, sizeof( mbedtls_pkcs7 ) );
+}
+
+static int pkcs7_get_next_content_len( unsigned char **p, unsigned char *end,
+                                       size_t *len )
+{
+    int ret;
+
+    if( ( ret = mbedtls_asn1_get_tag( p, end, len, MBEDTLS_ASN1_CONSTRUCTED
+                    | MBEDTLS_ASN1_CONTEXT_SPECIFIC ) ) != 0 )
+    {
+        return( MBEDTLS_ERR_PKCS7_INVALID_FORMAT + ret );
+    }
+
+    return( 0 );
+}
+
+/**
+ * version Version
+ * Version ::= INTEGER
+ **/
+static int pkcs7_get_version( unsigned char **p, unsigned char *end, int *ver )
+{
+    int ret;
+
+    if( ( ret = mbedtls_asn1_get_int( p, end, ver ) ) != 0 )
+        return( MBEDTLS_ERR_PKCS7_INVALID_VERSION + ret );
+
+    /* If version != 1, return invalid version */
+    if( *ver != MBEDTLS_PKCS7_SUPPORTED_VERSION )
+        return( MBEDTLS_ERR_PKCS7_INVALID_VERSION );
+
+    return( 0 );
+}
+
+/**
+ * ContentInfo ::= SEQUENCE {
+ *      contentType ContentType,
+ *      content
+ *              [0] EXPLICIT ANY DEFINED BY contentType OPTIONAL }
+ **/
+static int pkcs7_get_content_info_type( unsigned char **p, unsigned char *end,
+                                        mbedtls_pkcs7_buf *pkcs7 )
+{
+    size_t len = 0;
+    int ret;
+
+    ret = mbedtls_asn1_get_tag( p, end, &len, MBEDTLS_ASN1_CONSTRUCTED
+                                            | MBEDTLS_ASN1_SEQUENCE );
+    if( ret != 0 )
+        return( MBEDTLS_ERR_PKCS7_INVALID_CONTENT_INFO + ret );
+
+    ret = mbedtls_asn1_get_tag( p, end, &len, MBEDTLS_ASN1_OID );
+    if( ret != 0 )
+        return( MBEDTLS_ERR_PKCS7_INVALID_CONTENT_INFO + ret );
+
+    pkcs7->tag = MBEDTLS_ASN1_OID;
+    pkcs7->len = len;
+    pkcs7->p = *p;
+
+    return( ret );
+}
+
+/**
+ * DigestAlgorithmIdentifier ::= AlgorithmIdentifier
+ *
+ * This is from x509.h
+ **/
+static int pkcs7_get_digest_algorithm( unsigned char **p, unsigned char *end,
+                                       mbedtls_x509_buf *alg )
+{
+    int ret;
+
+    if( ( ret = mbedtls_asn1_get_alg_null( p, end, alg ) ) != 0 )
+        return( MBEDTLS_ERR_PKCS7_INVALID_ALG );
+
+    return( 0 );
+}
+
+/**
+ * DigestAlgorithmIdentifiers :: SET of DigestAlgorithmIdentifier
+ **/
+static int pkcs7_get_digest_algorithm_set( unsigned char **p,
+                                           unsigned char *end,
+                                           mbedtls_x509_buf *alg )
+{
+    size_t len = 0;
+    int ret;
+
+    ret = mbedtls_asn1_get_tag( p, end, &len, MBEDTLS_ASN1_CONSTRUCTED
+                                            | MBEDTLS_ASN1_SET );
+    if( ret != 0 )
+        return( MBEDTLS_ERR_PKCS7_INVALID_ALG + ret );
+
+    end = *p + len;
+
+    /** For now, it assumes there is only one digest algorithm specified **/
+    ret = mbedtls_asn1_get_alg_null( p, end, alg );
+    if( ret != 0 )
+        return( MBEDTLS_ERR_PKCS7_INVALID_ALG + ret );
+
+    if ( *p != end )
+        return ( MBEDTLS_ERR_PKCS7_INVALID_FORMAT );
+
+    return( 0 );
+}
+
+/**
+ * certificates :: SET OF ExtendedCertificateOrCertificate,
+ * ExtendedCertificateOrCertificate ::= CHOICE {
+ *      certificate Certificate -- x509,
+ *      extendedCertificate[0] IMPLICIT ExtendedCertificate }
+ **/
+static int pkcs7_get_certificates( unsigned char **p, unsigned char *end,
+                                   mbedtls_x509_crt *certs )
+{
+    int ret;
+    size_t len1 = 0;
+    size_t len2 = 0;
+    unsigned char *end_set, *end_cert;
+    unsigned char *start = *p;
+
+    if( ( ret = mbedtls_asn1_get_tag( p, end, &len1, MBEDTLS_ASN1_CONSTRUCTED
+                    | MBEDTLS_ASN1_CONTEXT_SPECIFIC ) ) != 0 )
+    {
+        if( ret == MBEDTLS_ERR_ASN1_UNEXPECTED_TAG )
+            return( 0 );
+
+        return( MBEDTLS_ERR_PKCS7_INVALID_FORMAT + ret );
+    }
+    start = *p;
+    end_set = *p + len1;
+
+    ret = mbedtls_asn1_get_tag( p, end_set, &len2, MBEDTLS_ASN1_CONSTRUCTED
+            | MBEDTLS_ASN1_SEQUENCE );
+    if( ret != 0 )
+        return( MBEDTLS_ERR_PKCS7_INVALID_CERT + ret );
+
+    end_cert = *p + len2;
+
+    /*
+     * This is to verify that there is only one signer certificate. It seems it is
+     * not easy to differentiate between the chain vs different signer's certificate.
+     * So, we support only the root certificate and the single signer.
+     * The behaviour would be improved with addition of multiple signer support.
+     */
+    if (end_cert != end_set)
+        return ( MBEDTLS_ERR_PKCS7_INVALID_CERT );
+
+    *p = start;
+    if( ( ret = mbedtls_x509_crt_parse( certs, *p, len1 ) ) < 0 )
+        return( MBEDTLS_ERR_PKCS7_INVALID_CERT );
+
+    *p = *p + len1;
+
+    return( 0 );
+}
+
+/**
+ * EncryptedDigest ::= OCTET STRING
+ **/
+static int pkcs7_get_signature( unsigned char **p, unsigned char *end,
+                                mbedtls_pkcs7_buf *signature )
+{
+    int ret;
+    size_t len = 0;
+
+    ret = mbedtls_asn1_get_tag( p, end, &len, MBEDTLS_ASN1_OCTET_STRING );
+    if( ret != 0 )
+        return( ret );
+
+    signature->tag = MBEDTLS_ASN1_OCTET_STRING;
+    signature->len = len;
+    signature->p = *p;
+
+    *p = *p + len;
+
+    return( 0 );
+}
+
+/**
+ * SignerInfos ::= SET of SignerInfo
+ * SignerInfo ::= SEQUENCE {
+ *      version Version;
+ *      issuerAndSerialNumber   IssuerAndSerialNumber,
+ *      digestAlgorithm DigestAlgorithmIdentifier,
+ *      authenticatedAttributes
+ *              [0] IMPLICIT Attributes OPTIONAL,
+ *      digestEncryptionAlgorithm DigestEncryptionAlgorithmIdentifier,
+ *      encryptedDigest EncryptedDigest,
+ *      unauthenticatedAttributes
+ *              [1] IMPLICIT Attributes OPTIONAL,
+ **/
+static int pkcs7_get_signers_info_set( unsigned char **p, unsigned char *end,
+                                       mbedtls_pkcs7_signer_info *signers_set )
+{
+    unsigned char *end_set, *end_set1;
+    int ret;
+    size_t len = 0;
+
+    ret = mbedtls_asn1_get_tag( p, end, &len, MBEDTLS_ASN1_CONSTRUCTED
+                                | MBEDTLS_ASN1_SET );
+    if( ret != 0 )
+        return( MBEDTLS_ERR_PKCS7_INVALID_SIGNER_INFO + ret );
+
+    end_set = *p + len;
+
+    ret = mbedtls_asn1_get_tag( p, end_set, &len, MBEDTLS_ASN1_CONSTRUCTED
+                                | MBEDTLS_ASN1_SEQUENCE );
+    if( ret != 0 )
+        return( MBEDTLS_ERR_PKCS7_INVALID_SIGNER_INFO + ret );
+
+    end_set1 = *p + len;
+    if (end_set1 != end_set)
+        return ( MBEDTLS_ERR_PKCS7_INVALID_SIGNER_INFO );
+
+    end_set = end_set1;
+
+    ret = mbedtls_asn1_get_int( p, end_set, &signers_set->version );
+    if( ret != 0 )
+        return( MBEDTLS_ERR_PKCS7_INVALID_SIGNER_INFO );
+
+    ret = mbedtls_asn1_get_tag( p, end_set, &len, MBEDTLS_ASN1_CONSTRUCTED
+                                | MBEDTLS_ASN1_SEQUENCE );
+    if( ret != 0 )
+        return( MBEDTLS_ERR_PKCS7_INVALID_SIGNER_INFO + ret );
+
+    /* Parsing IssuerAndSerialNumber */
+    signers_set->issuer_raw.p = *p;
+
+    ret = mbedtls_asn1_get_tag( p, end_set, &len, MBEDTLS_ASN1_CONSTRUCTED
+                                | MBEDTLS_ASN1_SEQUENCE );
+    if( ret != 0 )
+        return( MBEDTLS_ERR_PKCS7_INVALID_SIGNER_INFO + ret );
+
+    ret  = mbedtls_x509_get_name( p, *p + len, &signers_set->issuer );
+    if( ret != 0 )
+        return( MBEDTLS_ERR_PKCS7_INVALID_SIGNER_INFO );
+
+    signers_set->issuer_raw.len =  *p - signers_set->issuer_raw.p;
+
+    ret = mbedtls_x509_get_serial( p, end_set, &signers_set->serial );
+    if( ret != 0 )
+        return( MBEDTLS_ERR_PKCS7_INVALID_SIGNER_INFO );
+
+    ret = pkcs7_get_digest_algorithm( p, end_set, &signers_set->alg_identifier );
+    if( ret != 0 )
+        return( MBEDTLS_ERR_PKCS7_INVALID_SIGNER_INFO );
+
+    ret = pkcs7_get_digest_algorithm( p, end_set, &signers_set->sig_alg_identifier );
+    if( ret != 0 )
+        return( MBEDTLS_ERR_PKCS7_INVALID_SIGNER_INFO );
+
+    ret = pkcs7_get_signature( p, end_set, &signers_set->sig );
+    if( ret != 0 )
+        return( MBEDTLS_ERR_PKCS7_INVALID_SIGNER_INFO );
+
+    signers_set->next = NULL;
+
+    if (*p != end_set)
+        return ( MBEDTLS_ERR_PKCS7_INVALID_SIGNER_INFO );
+
+    return( 0 );
+}
+
+/**
+ * SignedData ::= SEQUENCE {
+ *      version Version,
+ *      digestAlgorithms DigestAlgorithmIdentifiers,
+ *      contentInfo ContentInfo,
+ *      certificates
+ *              [0] IMPLICIT ExtendedCertificatesAndCertificates
+ *                  OPTIONAL,
+ *      crls
+ *              [0] IMPLICIT CertificateRevocationLists OPTIONAL,
+ *      signerInfos SignerInfos }
+ */
+static int pkcs7_get_signed_data( unsigned char *buf, size_t buflen,
+                                  mbedtls_pkcs7_signed_data *signed_data )
+{
+    unsigned char *p = buf;
+    unsigned char *end = buf + buflen;
+    unsigned char *end_set;
+    size_t len = 0;
+    int ret;
+    mbedtls_md_type_t md_alg;
+
+    ret = mbedtls_asn1_get_tag( &p, end, &len, MBEDTLS_ASN1_CONSTRUCTED
+                                | MBEDTLS_ASN1_SEQUENCE );
+    if( ret != 0 )
+        return( MBEDTLS_ERR_PKCS7_INVALID_FORMAT + ret );
+
+    end_set = p + len;
+
+    /* Get version of signed data */
+    ret = pkcs7_get_version( &p, end_set, &signed_data->version );
+    if( ret != 0 )
+        return( ret );
+
+    /* Get digest algorithm */
+    ret = pkcs7_get_digest_algorithm_set( &p, end_set,
+            &signed_data->digest_alg_identifiers );
+    if( ret != 0 )
+        return( ret );
+
+    ret = mbedtls_oid_get_md_alg( &signed_data->digest_alg_identifiers, &md_alg );
+    if( ret != 0 )
+        return( MBEDTLS_ERR_PKCS7_INVALID_ALG );
+
+    /* Do not expect any content */
+    ret = pkcs7_get_content_info_type( &p, end_set, &signed_data->content.oid );
+    if( ret != 0 )
+        return( ret );
+
+    if( MBEDTLS_OID_CMP( MBEDTLS_OID_PKCS7_DATA, &signed_data->content.oid ) )
+    {
+        return( MBEDTLS_ERR_PKCS7_INVALID_CONTENT_INFO ) ;
+    }
+
+    p = p + signed_data->content.oid.len;
+
+    /* Look for certificates, there may or may not be any */
+    mbedtls_x509_crt_init( &signed_data->certs );
+    ret = pkcs7_get_certificates( &p, end_set, &signed_data->certs );
+    if( ret != 0 )
+        return( ret ) ;
+
+    /*
+     * Currently CRLs are not supported. If CRL exist, the parsing will fail
+     * at next step of getting signers info and return error as invalid
+     * signer info.
+     */
+
+    /* Get signers info */
+    ret = pkcs7_get_signers_info_set( &p, end_set, &signed_data->signers );
+    if( ret != 0 )
+        return( ret );
+
+    if ( p != end )
+        ret = MBEDTLS_ERR_PKCS7_INVALID_FORMAT;
+
+    return( ret );
+}
+
+int mbedtls_pkcs7_parse_der( const unsigned char *buf, const int buflen,
+                             mbedtls_pkcs7 *pkcs7 )
+{
+    unsigned char *start;
+    unsigned char *end;
+    size_t len = 0;
+    int ret;
+
+    /* use internal buffer for parsing */
+    start = (unsigned char *)buf;
+    end = start + buflen;
+
+    if( !pkcs7 )
+        return( MBEDTLS_ERR_PKCS7_BAD_INPUT_DATA );
+
+    ret = pkcs7_get_content_info_type( &start, end, &pkcs7->content_type_oid );
+    if( ret != 0 )
+        goto out;
+
+    if( ! MBEDTLS_OID_CMP( MBEDTLS_OID_PKCS7_DATA, &pkcs7->content_type_oid )
+     || ! MBEDTLS_OID_CMP( MBEDTLS_OID_PKCS7_ENCRYPTED_DATA, &pkcs7->content_type_oid )
+     || ! MBEDTLS_OID_CMP( MBEDTLS_OID_PKCS7_ENVELOPED_DATA, &pkcs7->content_type_oid )
+     || ! MBEDTLS_OID_CMP( MBEDTLS_OID_PKCS7_SIGNED_AND_ENVELOPED_DATA, &pkcs7->content_type_oid )
+     || ! MBEDTLS_OID_CMP( MBEDTLS_OID_PKCS7_DIGESTED_DATA, &pkcs7->content_type_oid )
+     || ! MBEDTLS_OID_CMP( MBEDTLS_OID_PKCS7_ENCRYPTED_DATA, &pkcs7->content_type_oid ) )
+    {
+        ret =  MBEDTLS_ERR_PKCS7_FEATURE_UNAVAILABLE;
+        goto out;
+    }
+
+    if( MBEDTLS_OID_CMP( MBEDTLS_OID_PKCS7_SIGNED_DATA, &pkcs7->content_type_oid ) )
+    {
+        ret = MBEDTLS_ERR_PKCS7_BAD_INPUT_DATA;
+        goto out;
+    }
+
+    start = start + pkcs7->content_type_oid.len;
+
+    ret = pkcs7_get_next_content_len( &start, end, &len );
+    if( ret != 0 )
+        goto out;
+
+    ret = pkcs7_get_signed_data( start, len, &pkcs7->signed_data );
+
+out:
+    if ( ret != 0 )
+        mbedtls_pkcs7_free( pkcs7 );
+    return( ret );
+}
+
+int mbedtls_pkcs7_signed_data_verify( mbedtls_pkcs7 *pkcs7,
+                                      mbedtls_x509_crt *cert,
+                                      const unsigned char *data,
+                                      size_t datalen )
+{
+
+    int ret;
+    unsigned char *hash;
+    mbedtls_pk_context pk_cxt = cert->pk;
+    const mbedtls_md_info_t *md_info;
+    mbedtls_md_type_t md_alg;
+
+    ret = mbedtls_oid_get_md_alg( &pkcs7->signed_data.digest_alg_identifiers, &md_alg );
+    if( ret != 0 )
+        return( MBEDTLS_ERR_PKCS7_VERIFY_FAIL );
+
+    md_info = mbedtls_md_info_from_type( md_alg );
+
+    hash = mbedtls_calloc( mbedtls_md_get_size( md_info ), 1 );
+    if( hash == NULL ) {
+        return( MBEDTLS_ERR_PKCS7_ALLOC_FAILED );
+    }
+
+    mbedtls_md( md_info, data, datalen, hash );
+
+    ret = mbedtls_pk_verify( &pk_cxt, md_alg, hash, sizeof(hash),
+                                      pkcs7->signed_data.signers.sig.p,
+                                      pkcs7->signed_data.signers.sig.len );
+
+    mbedtls_free( hash );
+
+    return( ret );
+}
+
+int mbedtls_pkcs7_signed_hash_verify( mbedtls_pkcs7 *pkcs7,
+                                      mbedtls_x509_crt *cert,
+                                      const unsigned char *hash, int hashlen)
+{
+    int ret;
+    mbedtls_md_type_t md_alg;
+    mbedtls_pk_context pk_cxt;
+
+    ret = mbedtls_oid_get_md_alg( &pkcs7->signed_data.digest_alg_identifiers, &md_alg );
+    if( ret != 0 )
+        return( MBEDTLS_ERR_PKCS7_VERIFY_FAIL );
+
+    pk_cxt = cert->pk;
+    ret = mbedtls_pk_verify( &pk_cxt, md_alg, hash, hashlen,
+                             pkcs7->signed_data.signers.sig.p,
+                             pkcs7->signed_data.signers.sig.len );
+
+    return ( ret );
+}
+
+/*
+ * Unallocate all pkcs7 data
+ */
+void mbedtls_pkcs7_free( mbedtls_pkcs7 *pkcs7 )
+{
+    mbedtls_x509_name *name_cur;
+    mbedtls_x509_name *name_prv;
+
+    if( pkcs7 == NULL )
+        return;
+
+    mbedtls_x509_crt_free( &pkcs7->signed_data.certs );
+    mbedtls_x509_crl_free( &pkcs7->signed_data.crl );
+
+    name_cur = pkcs7->signed_data.signers.issuer.next;
+    while( name_cur != NULL )
+    {
+        name_prv = name_cur;
+        name_cur = name_cur->next;
+        mbedtls_platform_zeroize( name_prv, sizeof( mbedtls_x509_name ) );
+        mbedtls_free( name_prv );
+    }
+
+    mbedtls_platform_zeroize( pkcs7, sizeof( mbedtls_pkcs7 ) );
+}
+
+#endif

--- a/library/pkcs7.c
+++ b/library/pkcs7.c
@@ -31,8 +31,10 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
+#if defined(MBEDTLS_FS_IO)
 #include <sys/types.h>
 #include <sys/stat.h>
+#endif
 #include <unistd.h>
 
 #if defined(MBEDTLS_PLATFORM_C)
@@ -54,6 +56,7 @@
 #include <time.h>
 #endif
 
+#if defined(MBEDTLS_FS_IO)
 /*
  * Load all data from a file into a given buffer.
  *
@@ -91,6 +94,7 @@ int mbedtls_pkcs7_load_file( const char *path, unsigned char **buf, size_t *n )
 
     return( 0 );
 }
+#endif
 
 /**
  * Initializes the pkcs7 structure.

--- a/library/pkcs7.c
+++ b/library/pkcs7.c
@@ -143,6 +143,7 @@ static int pkcs7_get_content_info_type( unsigned char **p, unsigned char *end,
 {
     size_t len = 0;
     int ret;
+    unsigned char *start = *p;
 
     ret = mbedtls_asn1_get_tag( p, end, &len, MBEDTLS_ASN1_CONSTRUCTED
                                             | MBEDTLS_ASN1_SEQUENCE );
@@ -150,8 +151,10 @@ static int pkcs7_get_content_info_type( unsigned char **p, unsigned char *end,
         return( MBEDTLS_ERR_PKCS7_INVALID_CONTENT_INFO + ret );
 
     ret = mbedtls_asn1_get_tag( p, end, &len, MBEDTLS_ASN1_OID );
-    if( ret != 0 )
+    if( ret != 0 ) {
+        *p = start;
         return( MBEDTLS_ERR_PKCS7_INVALID_CONTENT_INFO + ret );
+	}
 
     pkcs7->tag = MBEDTLS_ASN1_OID;
     pkcs7->len = len;
@@ -448,6 +451,7 @@ int mbedtls_pkcs7_parse_der( const unsigned char *buf, const int buflen,
     unsigned char *end;
     size_t len = 0;
     int ret;
+    int isoidset = 0;
 
     /* use internal buffer for parsing */
     start = (unsigned char *)buf;
@@ -458,7 +462,10 @@ int mbedtls_pkcs7_parse_der( const unsigned char *buf, const int buflen,
 
     ret = pkcs7_get_content_info_type( &start, end, &pkcs7->content_type_oid );
     if( ret != 0 )
-        goto out;
+    {
+        len = buflen;
+        goto try_data;
+    }
 
     if( ! MBEDTLS_OID_CMP( MBEDTLS_OID_PKCS7_DATA, &pkcs7->content_type_oid )
      || ! MBEDTLS_OID_CMP( MBEDTLS_OID_PKCS7_ENCRYPTED_DATA, &pkcs7->content_type_oid )
@@ -477,17 +484,31 @@ int mbedtls_pkcs7_parse_der( const unsigned char *buf, const int buflen,
         goto out;
     }
 
+    isoidset = 1;
     start = start + pkcs7->content_type_oid.len;
 
     ret = pkcs7_get_next_content_len( &start, end, &len );
     if( ret != 0 )
         goto out;
 
+try_data:
     ret = pkcs7_get_signed_data( start, len, &pkcs7->signed_data );
+    if (ret != 0)
+        goto out;
+
+    if (!isoidset)
+    {
+        pkcs7->content_type_oid.tag = MBEDTLS_ASN1_OID;
+        pkcs7->content_type_oid.len = MBEDTLS_OID_SIZE(MBEDTLS_OID_PKCS7_SIGNED_DATA);
+        pkcs7->content_type_oid.p = (unsigned char *)MBEDTLS_OID_PKCS7_SIGNED_DATA;
+    }
+
+    ret = MBEDTLS_PKCS7_SIGNED_DATA;
 
 out:
-    if ( ret != 0 )
+    if ( ret < 0 )
         mbedtls_pkcs7_free( pkcs7 );
+
     return( ret );
 }
 

--- a/library/version_features.c
+++ b/library/version_features.c
@@ -792,7 +792,10 @@ static const char *features[] = {
 #endif /* MBEDTLS_X509_CSR_WRITE_C */
 #if defined(MBEDTLS_XTEA_C)
     "MBEDTLS_XTEA_C",
-#endif /* MBEDTLS_XTEA_C */
+#endif /* MBEDTLS_PKCS7_USE_C */
+#if defined(MBEDTLS_PKCS7_USE_C)
+    "MBEDTLS_PKCS7_USE_C",
+#endif /* MBEDTLS_PKCS7_USE_C */
 #endif /* MBEDTLS_VERSION_FEATURES */
     NULL
 };

--- a/library/version_features.c
+++ b/library/version_features.c
@@ -715,6 +715,9 @@ static const char *features[] = {
 #if defined(MBEDTLS_PKCS5_C)
     "MBEDTLS_PKCS5_C",
 #endif /* MBEDTLS_PKCS5_C */
+#if defined(MBEDTLS_PKCS7_C)
+    "MBEDTLS_PKCS7_C",
+#endif /* MBEDTLS_PKCS7_C */
 #if defined(MBEDTLS_PKCS11_C)
     "MBEDTLS_PKCS11_C",
 #endif /* MBEDTLS_PKCS11_C */
@@ -792,10 +795,7 @@ static const char *features[] = {
 #endif /* MBEDTLS_X509_CSR_WRITE_C */
 #if defined(MBEDTLS_XTEA_C)
     "MBEDTLS_XTEA_C",
-#endif /* MBEDTLS_PKCS7_USE_C */
-#if defined(MBEDTLS_PKCS7_USE_C)
-    "MBEDTLS_PKCS7_USE_C",
-#endif /* MBEDTLS_PKCS7_USE_C */
+#endif /* MBEDTLS_XTEA_C */
 #endif /* MBEDTLS_VERSION_FEATURES */
     NULL
 };

--- a/programs/ssl/query_config.c
+++ b/programs/ssl/query_config.c
@@ -2051,6 +2051,14 @@ int query_config( const char *config )
     }
 #endif /* MBEDTLS_VERSION_C */
 
+#if defined(MBEDTLS_PKCS7_C)
+    if( strcmp( "MBEDTLS_PKCS7_C", config ) == 0 )
+    {
+        MACRO_EXPANSION_TO_STR( MBEDTLS_PKCS7_C );
+        return( 0 );
+    }
+#endif /* MBEDTLS_PKCS7_C */
+
 #if defined(MBEDTLS_X509_USE_C)
     if( strcmp( "MBEDTLS_X509_USE_C", config ) == 0 )
     {

--- a/scripts/generate_errors.pl
+++ b/scripts/generate_errors.pl
@@ -78,7 +78,7 @@ my @low_level_modules = qw( AES ARC4 ARIA ASN1 BASE64 BIGNUM BLOWFISH
                             SHA1 SHA256 SHA512 THREADING XTEA );
 my @high_level_modules = qw( CIPHER DHM ECP MD
                              PEM PK PKCS12 PKCS5
-                             RSA SSL X509 );
+                             RSA SSL X509 PKCS7 );
 
 my $line_separator = $/;
 undef $/;
@@ -140,6 +140,7 @@ foreach my $line (@matches)
     $define_name = "ASN1_PARSE" if ($define_name eq "ASN1");
     $define_name = "SSL_TLS" if ($define_name eq "SSL");
     $define_name = "PEM_PARSE,PEM_WRITE" if ($define_name eq "PEM");
+    $define_name = "PKCS7" if ($define_name eq "PKCS7");
 
     my $include_name = $module_name;
     $include_name =~ tr/A-Z/a-z/;

--- a/tests/data_files/Makefile
+++ b/tests/data_files/Makefile
@@ -1048,6 +1048,94 @@ cert_md5.crt: cert_md5.csr
 	$(MBEDTLS_CERT_WRITE) request_file=$< serial=6 issuer_crt=$(test_ca_crt) issuer_key=$(test_ca_key_file_rsa) issuer_pwd=$(test_ca_pwd_rsa) not_before=20190210144406 not_after=20290210144406 md=MD5 version=3 output_file=$@
 all_final += cert_md5.crt
 
+#PKCS7 test data
+pkcs7_test_cert_1 = pkcs7-rsa-sha256-1.crt
+pkcs7_test_cert_2 = pkcs7-rsa-sha256-2.crt
+pkcs7_test_file = pkcs7_data.txt
+
+#Generate signing cert
+pkcs7-rsa-sha256-1.crt:
+	$(OPENSSL) req -x509 -subj="/C=NL/O=PKCS7/CN=PKCS7 Cert 1" -sha256 -nodes -days 365  -newkey rsa:2048 -keyout pkcs7-rsa-sha256-1.key -out pkcs7-rsa-sha256-1.crt
+	cat pkcs7-rsa-sha256-1.crt > pkcs7-rsa-sha256-1.pem
+	cat pkcs7-rsa-sha256-1.key >> pkcs7-rsa-sha256-1.pem
+all_final += pkcs7-rsa-sha256-1.crt
+
+pkcs7-rsa-sha256-2.crt:
+	$(OPENSSL) req -x509 -subj="/C=NL/O=PKCS7/CN=PKCS7 Cert 2" -sha256 -nodes -days 365  -newkey rsa:2048 -keyout pkcs7-rsa-sha256-2.key -out pkcs7-rsa-sha256-2.crt
+	cat pkcs7-rsa-sha256-2.crt > pkcs7-rsa-sha256-2.pem
+	cat pkcs7-rsa-sha256-2.key >> pkcs7-rsa-sha256-2.pem
+all_final += pkcs7-rsa-sha256-2.crt
+
+#Generate data file to be signed
+pkcs7_data.txt:
+	echo "Hello" > $@
+	echo 2 >> pkcs7_data_1.txt
+all_final += pkcs7_data.txt
+
+#pkcs7 signature file with CERT
+pkcs7_data_cert.signed.sha256: pkcs7_data.txt pkcs7-rsa-sha256-1.crt
+	$(OPENSSL) smime -sign -binary -in pkcs7_data.txt -out $@ -md sha256 -signer pkcs7-rsa-sha256-1.pem -noattr -outform DER -out $@
+all_final += pkcs7_data_cert.signed.sha256
+
+#pkcs7 signature file with CERT and sha1
+pkcs7_data_cert.signed.sha1: pkcs7_data.txt
+	$(OPENSSL) smime -sign -binary -in pkcs7_data.txt -out $@ -md sha1 -signer pkcs7-rsa-sha256-1.pem -noattr -outform DER -out $@
+all_final += pkcs7_data_cert.signed.sha1
+
+#pkcs7 signature file with CERT and sha512
+pkcs7_data_cert.signed.sha512: pkcs7_data.txt
+	$(OPENSSL) smime -sign -binary -in pkcs7_data.txt -out $@ -md sha512 -signer pkcs7-rsa-sha256-1.pem -noattr -outform DER -out $@
+all_final += pkcs7_data_cert.signed.sha512
+
+#pkcs7 signature file without CERT
+pkcs7_data_without_cert.signed: pkcs7_data.txt
+	$(OPENSSL) smime -sign -binary -in pkcs7_data.txt -out $@ -md sha256 -signer pkcs7-rsa-sha256-1.pem -nocerts -noattr -outform DER -out $@
+all_final += pkcs7_data_without_cert.signed
+
+#pkcs7 signature file with multiple signers
+pkcs7_data_multiple.signed: pkcs7_data.txt
+	$(OPENSSL) smime -sign -binary -in pkcs7_data.txt -out $@ -md sha256 -signer pkcs7-rsa-sha256-1.pem -signer pkcs7-rsa-sha256-2.pem -nocerts -noattr -outform DER -out $@
+all_final += pkcs7_data_multiple.signed
+
+#pkcs7 signature file with multiple certificates
+pkcs7_data_multiple_certs.signed: pkcs7_data.txt
+	$(OPENSSL) smime -sign -binary -in pkcs7_data.txt -out $@ -md sha256 -signer pkcs7-rsa-sha256-1.pem -signer pkcs7-rsa-sha256-2.pem -noattr -outform DER -out $@
+all_final += pkcs7_data_multiple_certs.signed
+
+#pkcs7 signature file with corrupted CERT
+pkcs7_data.signed.badcert: pkcs7_data.txt
+	cp pkcs7_data_cert.signed.sha256 $@
+	echo -en '\xa1' | dd of=$@ bs=1 seek=547 conv=notrunc
+all_final += pkcs7_data.signed.badcert
+
+#pkcs7 signature file with corrupted signer info
+pkcs7_data.signed.badsigner: pkcs7_data.txt
+	cp pkcs7_data_cert.signed.sha256 $@
+	echo -en '\xa1' | dd of=$@ bs=1 seek=918 conv=notrunc
+all_final += pkcs7_data.signed.badsigner
+
+#pkcs7 file with CRL
+pkcs7_data_crl.signed:
+		cat pkcs7-rsa-sha256-1.pem > pkcs7-rsa-crt-crl.pem
+		cat crl_sha256.pem >> pkcs7-rsa-crt-crl.pem
+		$(OPENSSL) smime -sign -binary -in pkcs7_data.txt -out $@ -md sha512 -signer pkcs7-rsa-crt-crl.pem -inkey pkcs7-rsa-sha256-1.key -noattr -outform DER -out $@
+all_final += pkcs7_data_crl.signed
+
+#pkcs7 file without CRL
+pkcs7_data_without_crl.signed:
+	    openssl crl2pkcs7 -nocrl -certfile pkcs7-rsa-sha256-1.pem -outform DER -out $@
+all_final += pkcs7_data_without_crl.signed
+
+#pkcs7 file with version 2
+pkcs7_data_cert.signed.v2:
+	cp pkcs7_data_cert.signed.sha256 $@
+	echo -en '\x02' | dd of=$@ bs=1 seek=25 conv=notrunc
+all_final += pkcs7_data_cert.signed.v2
+
+pkcs7_data_cert.encrypted:
+	openssl smime -encrypt -aes256 -in pkcs7_data.txt -binary -outform DER -out $@ pkcs7-rsa-sha256-1.crt
+all_final += pkcs7_data_cert.encrypted
+
 ################################################################
 #### Meta targets
 ################################################################

--- a/tests/data_files/Makefile
+++ b/tests/data_files/Makefile
@@ -1136,6 +1136,11 @@ pkcs7_data_cert.encrypted:
 	openssl smime -encrypt -aes256 -in pkcs7_data.txt -binary -outform DER -out $@ pkcs7-rsa-sha256-1.crt
 all_final += pkcs7_data_cert.encrypted
 
+#pkcs7 signature file just with signed data
+pkcs7_data_cert.signeddata.sha256: pkcs7_data_cert.signed.sha256
+	dd if=pkcs7_data_cert.signed.sha256 of=pkcs7_data_cert.signeddata.sha256 skip=19 bs=1
+all_final += pkcs7_data_cert.signeddata.sha256
+
 ################################################################
 #### Meta targets
 ################################################################

--- a/tests/suites/test_suite_pkcs7.data
+++ b/tests/suites/test_suite_pkcs7.data
@@ -1,0 +1,64 @@
+PKCS7 Signed Data Parse Pass SHA256 #1
+depends_on:MBEDTLS_PKCS7_C
+pkcs7_parse:"data_files/pkcs7_data_cert.signed.sha256"
+
+PKCS7 Signed Data Parse Pass SHA1 #2
+depends_on:MBEDTLS_PKCS7_C
+pkcs7_parse:"data_files/pkcs7_data_cert.signed.sha1"
+
+PKCS7 Signed Data Parse Pass Without CERT #3
+depends_on:MBEDTLS_PKCS7_C
+pkcs7_parse_without_cert:"data_files/pkcs7_data_without_cert.signed"
+
+PKCS7 Signed Data Parse Fail with multiple signers #4
+depends_on:MBEDTLS_PKCS7_C
+pkcs7_parse_multiple_signers:"data_files/pkcs7_data_multiple.signed"
+
+PKCS7 Signed Data Parse Fail with multiple certs #4
+depends_on:MBEDTLS_PKCS7_C
+pkcs7_parse_multiple_signers:"data_files/pkcs7_data_multiple_certs.signed"
+
+PKCS7 Signed Data Parse Fail with corrupted cert #5
+depends_on:MBEDTLS_PKCS7_C
+pkcs7_parse_corrupted_cert:"data_files/pkcs7_data.signed.badcert"
+
+PKCS7 Signed Data Parse Fail with corrupted signer info #6
+depends_on:MBEDTLS_PKCS7_C
+pkcs7_parse_corrupted_signer_info:"data_files/pkcs7_data.signed.badsigner"
+
+PKCS7 Signed Data Parse Fail Version other than 1 #7
+depends_on:MBEDTLS_PKCS7_C
+pkcs7_parse_version:"data_files/pkcs7_data_cert.signed.v2"
+
+PKCS7 Signed Data Parse Fail Encrypted Content #8
+depends_on:MBEDTLS_PKCS7_C
+pkcs7_parse_content_oid:"data_files/pkcs7_data_cert.encrypted"
+
+#PKCS7 Signed Data Parse certificate chain #9
+#depends_on:MBEDTLS_PKCS7_C
+#pkcs7_parse_cert_chain:"data_files/pkcs7.data.signed.certchain"
+
+PKCS7 Signed Data Verification Pass SHA256 #10
+depends_on:MBEDTLS_PKCS7_C
+pkcs7_verify:"data_files/pkcs7_data_cert.signed.sha256":"data_files/pkcs7-rsa-sha256-1.crt":"data_files/pkcs7_data.txt"
+
+PKCS7 Signed Data Verification Pass SHA256 #10.1
+depends_on:MBEDTLS_PKCS7_C
+pkcs7_verify_hash:"data_files/pkcs7_data_cert.signed.sha256":"data_files/pkcs7-rsa-sha256-1.crt":"data_files/pkcs7_data.txt"
+
+PKCS7 Signed Data Verification Pass SHA1 #11
+depends_on:MBEDTLS_PKCS7_C
+pkcs7_verify:"data_files/pkcs7_data_cert.signed.sha1":"data_files/pkcs7-rsa-sha256-1.crt":"data_files/pkcs7_data.txt"
+
+PKCS7 Signed Data Verification Pass SHA512 #12
+depends_on:MBEDTLS_PKCS7_C:MBEDTLS_SHA512_C
+pkcs7_verify:"data_files/pkcs7_data_cert.signed.sha512":"data_files/pkcs7-rsa-sha256-1.crt":"data_files/pkcs7_data.txt"
+
+PKCS7 Signed Data Verification Fail because of different certificate #13
+depends_on:MBEDTLS_PKCS7_C
+pkcs7_verify_badcert:"data_files/pkcs7_data_cert.signed.sha256":"data_files/pkcs7-rsa-sha256-2.crt":"data_files/pkcs7_data.txt"
+
+PKCS7 Signed Data Verification Fail because of different data hash #14
+depends_on:MBEDTLS_PKCS7_C
+pkcs7_verify_tampered_data:"data_files/pkcs7_data_cert.signed.sha256":"data_files/pkcs7-rsa-sha256-1.crt":"data_files/pkcs7_data_1.txt"
+

--- a/tests/suites/test_suite_pkcs7.data
+++ b/tests/suites/test_suite_pkcs7.data
@@ -62,3 +62,6 @@ PKCS7 Signed Data Verification Fail because of different data hash #14
 depends_on:MBEDTLS_PKCS7_C
 pkcs7_verify_tampered_data:"data_files/pkcs7_data_cert.signed.sha256":"data_files/pkcs7-rsa-sha256-1.crt":"data_files/pkcs7_data_1.txt"
 
+PKCS7 Only Signed Data Parse Pass #15
+depends_on:MBEDTLS_PKCS7_C
+pkcs7_parse:"data_files/pkcs7_data_cert.signeddata.sha256"

--- a/tests/suites/test_suite_pkcs7.function
+++ b/tests/suites/test_suite_pkcs7.function
@@ -29,7 +29,7 @@ void pkcs7_parse( char *pkcs7_file )
     TEST_ASSERT( res == 0 );
 
     res = mbedtls_pkcs7_parse_der( pkcs7_buf, buflen, &pkcs7 );
-    TEST_ASSERT( res == 0 );
+    TEST_ASSERT( res == MBEDTLS_PKCS7_SIGNED_DATA );
 
 exit:
     mbedtls_free( pkcs7_buf );
@@ -52,7 +52,7 @@ void pkcs7_parse_without_cert( char *pkcs7_file )
     TEST_ASSERT( res == 0 );
 
     res = mbedtls_pkcs7_parse_der( pkcs7_buf, buflen, &pkcs7 );
-    TEST_ASSERT( res == 0 );
+    TEST_ASSERT( res == MBEDTLS_PKCS7_SIGNED_DATA );
 
 exit:
     mbedtls_free( pkcs7_buf );
@@ -210,7 +210,7 @@ void pkcs7_verify( char *pkcs7_file, char *crt, char *filetobesigned )
     TEST_ASSERT( res == 0 );
 
     res = mbedtls_pkcs7_parse_der( pkcs7_buf, buflen, &pkcs7 );
-    TEST_ASSERT( res == 0 );
+    TEST_ASSERT( res == MBEDTLS_PKCS7_SIGNED_DATA );
 
     res = stat(filetobesigned, &st);
     TEST_ASSERT( res == 0 );
@@ -263,7 +263,7 @@ void pkcs7_verify_hash( char *pkcs7_file, char *crt, char *filetobesigned )
     TEST_ASSERT( res == 0 );
 
     res = mbedtls_pkcs7_parse_der( pkcs7_buf, buflen, &pkcs7 );
-    TEST_ASSERT( res == 0 );
+    TEST_ASSERT( res == MBEDTLS_PKCS7_SIGNED_DATA );
 
     res = stat(filetobesigned, &st);
     TEST_ASSERT( res == 0 );
@@ -319,7 +319,7 @@ void pkcs7_verify_badcert( char *pkcs7_file, char *crt, char *filetobesigned )
     TEST_ASSERT( res == 0 );
 
     res = mbedtls_pkcs7_parse_der( pkcs7_buf, buflen, &pkcs7 );
-    TEST_ASSERT( res == 0 );
+    TEST_ASSERT( res == MBEDTLS_PKCS7_SIGNED_DATA );
 
     res = mbedtls_x509_crt_parse_file( &x509, crt );
     TEST_ASSERT( res == 0 );
@@ -369,7 +369,7 @@ void pkcs7_verify_tampered_data( char *pkcs7_file, char *crt, char *filetobesign
     TEST_ASSERT( res == 0 );
 
     res = mbedtls_pkcs7_parse_der( pkcs7_buf, buflen, &pkcs7 );
-    TEST_ASSERT( res == 0 );
+    TEST_ASSERT( res == MBEDTLS_PKCS7_SIGNED_DATA );
 
     res = mbedtls_x509_crt_parse_file( &x509, crt );
     TEST_ASSERT( res == 0 );

--- a/tests/suites/test_suite_pkcs7.function
+++ b/tests/suites/test_suite_pkcs7.function
@@ -1,0 +1,400 @@
+/* BEGIN_HEADER */
+#include "mbedtls/bignum.h"
+#include "mbedtls/pkcs7.h"
+#include "mbedtls/x509.h"
+#include "mbedtls/x509_crt.h"
+#include "mbedtls/x509_crl.h"
+#include "mbedtls/oid.h"
+#include "sys/types.h"
+#include "sys/stat.h"
+#include "unistd.h"
+/* END_HEADER */
+
+/* BEGIN_DEPENDENCIES
+ * END_DEPENDENCIES
+ */
+
+/* BEGIN_CASE */
+void pkcs7_parse( char *pkcs7_file )
+{
+    unsigned char *pkcs7_buf = NULL;
+    size_t buflen;
+    int res;
+
+    mbedtls_pkcs7 pkcs7;
+
+    mbedtls_pkcs7_init( &pkcs7 );
+
+    res = mbedtls_pkcs7_load_file( pkcs7_file, &pkcs7_buf, &buflen );
+    TEST_ASSERT( res == 0 );
+
+    res = mbedtls_pkcs7_parse_der( pkcs7_buf, buflen, &pkcs7 );
+    TEST_ASSERT( res == 0 );
+
+exit:
+    mbedtls_free( pkcs7_buf );
+    mbedtls_pkcs7_free( &pkcs7 );
+}
+/* END_CASE */
+
+/* BEGIN_CASE */
+void pkcs7_parse_without_cert( char *pkcs7_file )
+{
+    unsigned char *pkcs7_buf = NULL;
+    size_t buflen;
+    int res;
+
+    mbedtls_pkcs7 pkcs7;
+
+    mbedtls_pkcs7_init( &pkcs7 );
+
+    res = mbedtls_pkcs7_load_file( pkcs7_file, &pkcs7_buf, &buflen );
+    TEST_ASSERT( res == 0 );
+
+    res = mbedtls_pkcs7_parse_der( pkcs7_buf, buflen, &pkcs7 );
+    TEST_ASSERT( res == 0 );
+
+exit:
+    mbedtls_free( pkcs7_buf );
+    mbedtls_pkcs7_free( &pkcs7 );
+}
+/* END_CASE */
+
+/* BEGIN_CASE */
+void pkcs7_parse_multiple_signers( char *pkcs7_file )
+{
+    unsigned char *pkcs7_buf = NULL;
+    size_t buflen;
+    int res;
+
+    mbedtls_pkcs7 pkcs7;
+
+    mbedtls_pkcs7_init( &pkcs7 );
+
+    res = mbedtls_pkcs7_load_file( pkcs7_file, &pkcs7_buf, &buflen );
+    TEST_ASSERT( res == 0 );
+
+    res = mbedtls_pkcs7_parse_der( pkcs7_buf, buflen, &pkcs7 );
+    TEST_ASSERT( res < 0 );
+
+	switch ( res ){
+		case MBEDTLS_ERR_PKCS7_INVALID_CERT:
+			TEST_ASSERT( res ==  MBEDTLS_ERR_PKCS7_INVALID_CERT );
+			break;
+
+		case MBEDTLS_ERR_PKCS7_INVALID_SIGNER_INFO:
+			TEST_ASSERT( res == MBEDTLS_ERR_PKCS7_INVALID_SIGNER_INFO );
+			break;
+		default:
+			TEST_ASSERT(0);
+	}
+
+exit:
+    mbedtls_free( pkcs7_buf );
+    mbedtls_pkcs7_free( &pkcs7 );
+}
+/* END_CASE */
+
+/* BEGIN_CASE */
+void pkcs7_parse_corrupted_cert( char *pkcs7_file )
+{
+    unsigned char *pkcs7_buf = NULL;
+    size_t buflen;
+    int res;
+
+    mbedtls_pkcs7 pkcs7;
+
+    mbedtls_pkcs7_init( &pkcs7 );
+
+    res = mbedtls_pkcs7_load_file( pkcs7_file, &pkcs7_buf, &buflen );
+    TEST_ASSERT( res == 0 );
+
+    res = mbedtls_pkcs7_parse_der( pkcs7_buf, buflen, &pkcs7 );
+    TEST_ASSERT( res == MBEDTLS_ERR_PKCS7_INVALID_CERT );
+
+exit:
+    mbedtls_free( pkcs7_buf );
+    mbedtls_pkcs7_free( &pkcs7 );
+}
+/* END_CASE */
+
+/* BEGIN_CASE */
+void pkcs7_parse_corrupted_signer_info( char *pkcs7_file )
+{
+    unsigned char *pkcs7_buf = NULL;
+    size_t buflen;
+    int res;
+
+    mbedtls_pkcs7 pkcs7;
+
+    mbedtls_pkcs7_init( &pkcs7 );
+
+    res = mbedtls_pkcs7_load_file( pkcs7_file, &pkcs7_buf, &buflen );
+    TEST_ASSERT( res == 0 );
+
+    res = mbedtls_pkcs7_parse_der( pkcs7_buf, buflen, &pkcs7 );
+    TEST_ASSERT( res < 0 );
+
+exit:
+    mbedtls_free( pkcs7_buf );
+    mbedtls_pkcs7_free( &pkcs7 );
+}
+/* END_CASE */
+
+/* BEGIN_CASE */
+void pkcs7_parse_version( char *pkcs7_file )
+{
+    unsigned char *pkcs7_buf = NULL;
+    size_t buflen;
+    int res;
+
+    mbedtls_pkcs7 pkcs7;
+
+    mbedtls_pkcs7_init( &pkcs7 );
+
+    res = mbedtls_pkcs7_load_file( pkcs7_file, &pkcs7_buf, &buflen );
+    TEST_ASSERT( res == 0 );
+
+    res = mbedtls_pkcs7_parse_der( pkcs7_buf, buflen, &pkcs7 );
+    TEST_ASSERT( res == MBEDTLS_ERR_PKCS7_INVALID_VERSION );
+
+exit:
+    mbedtls_free( pkcs7_buf );
+    mbedtls_pkcs7_free( &pkcs7 );
+}
+/* END_CASE */
+
+/* BEGIN_CASE */
+void pkcs7_parse_content_oid( char *pkcs7_file )
+{
+    unsigned char *pkcs7_buf = NULL;
+    size_t buflen;
+    int res;
+    mbedtls_pkcs7 pkcs7;
+
+    mbedtls_pkcs7_init( &pkcs7 );
+
+    res = mbedtls_pkcs7_load_file( pkcs7_file, &pkcs7_buf, &buflen);
+    TEST_ASSERT( res == 0 );
+
+    res = mbedtls_pkcs7_parse_der( pkcs7_buf, buflen, &pkcs7 );
+    TEST_ASSERT( res != 0 );
+    TEST_ASSERT( res == MBEDTLS_ERR_PKCS7_FEATURE_UNAVAILABLE );
+exit:
+    mbedtls_free( pkcs7_buf );
+    mbedtls_pkcs7_free( &pkcs7 );
+}
+/* END_CASE */
+
+/* BEGIN_CASE */
+void pkcs7_verify( char *pkcs7_file, char *crt, char *filetobesigned )
+{
+    unsigned char *pkcs7_buf = NULL;
+    size_t buflen;
+    unsigned char *data = NULL;
+    struct stat st;
+    size_t datalen;
+    int res;
+    FILE *file;
+
+    mbedtls_pkcs7 pkcs7;
+    mbedtls_x509_crt x509;
+
+    mbedtls_pkcs7_init( &pkcs7 );
+    mbedtls_x509_crt_init( &x509 );
+
+    res = mbedtls_x509_crt_parse_file( &x509, crt );
+    TEST_ASSERT( res == 0 );
+
+    res = mbedtls_pkcs7_load_file( pkcs7_file, &pkcs7_buf, &buflen );
+    TEST_ASSERT( res == 0 );
+
+    res = mbedtls_pkcs7_parse_der( pkcs7_buf, buflen, &pkcs7 );
+    TEST_ASSERT( res == 0 );
+
+    res = stat(filetobesigned, &st);
+    TEST_ASSERT( res == 0 );
+
+    file = fopen( filetobesigned, "r" );
+    TEST_ASSERT( file != NULL );
+
+    datalen = st.st_size;
+    data = ( unsigned char* ) calloc( datalen, sizeof( unsigned char ) );
+    buflen = fread( ( void * )data , sizeof( unsigned char ), datalen, file );
+    TEST_ASSERT( buflen == datalen);
+
+    fclose(file);
+
+    res = mbedtls_pkcs7_signed_data_verify( &pkcs7, &x509, data, datalen );
+    TEST_ASSERT( res == 0 );
+
+exit:
+    mbedtls_x509_crt_free( &x509 );
+    mbedtls_free( data );
+    mbedtls_free( pkcs7_buf );
+    mbedtls_pkcs7_free( &pkcs7 );
+}
+/* END_CASE */
+
+/* BEGIN_CASE */
+void pkcs7_verify_hash( char *pkcs7_file, char *crt, char *filetobesigned )
+{
+    unsigned char *pkcs7_buf = NULL;
+    size_t buflen;
+    unsigned char *data = NULL;
+    unsigned char hash[32];
+    struct stat st;
+    size_t datalen;
+    int res;
+    FILE *file;
+    const mbedtls_md_info_t *md_info;
+    mbedtls_md_type_t md_alg;
+
+    mbedtls_pkcs7 pkcs7;
+    mbedtls_x509_crt x509;
+
+    mbedtls_pkcs7_init( &pkcs7 );
+    mbedtls_x509_crt_init( &x509 );
+
+    res = mbedtls_x509_crt_parse_file( &x509, crt );
+    TEST_ASSERT( res == 0 );
+
+    res = mbedtls_pkcs7_load_file( pkcs7_file, &pkcs7_buf, &buflen );
+    TEST_ASSERT( res == 0 );
+
+    res = mbedtls_pkcs7_parse_der( pkcs7_buf, buflen, &pkcs7 );
+    TEST_ASSERT( res == 0 );
+
+    res = stat(filetobesigned, &st);
+    TEST_ASSERT( res == 0 );
+
+    file = fopen( filetobesigned, "r" );
+    TEST_ASSERT( file != NULL );
+
+    datalen = st.st_size;
+    data = ( unsigned char* ) calloc( datalen, sizeof( unsigned char ) );
+    TEST_ASSERT( data != NULL);
+
+    buflen = fread( (void *)data , sizeof( unsigned char ), datalen, file );
+    TEST_ASSERT( buflen == datalen);
+    fclose( file );
+
+    res = mbedtls_oid_get_md_alg( &(pkcs7.signed_data.digest_alg_identifiers), &md_alg );
+    TEST_ASSERT( res == 0 );
+    TEST_ASSERT( md_alg == MBEDTLS_MD_SHA256 );
+
+    md_info = mbedtls_md_info_from_type( md_alg );
+
+    mbedtls_md( md_info, data, datalen, hash );
+
+    res = mbedtls_pkcs7_signed_hash_verify( &pkcs7, &x509, hash, sizeof(hash));
+    TEST_ASSERT( res == 0 );
+
+exit:
+    mbedtls_x509_crt_free( &x509 );
+    mbedtls_free( data );
+    mbedtls_free( pkcs7_buf );
+    mbedtls_pkcs7_free( &pkcs7 );
+}
+/* END_CASE */
+
+/* BEGIN_CASE */
+void pkcs7_verify_badcert( char *pkcs7_file, char *crt, char *filetobesigned )
+{
+    unsigned char *pkcs7_buf = NULL;
+    size_t buflen;
+    unsigned char *data = NULL;
+    struct stat st;
+    size_t datalen;
+    int res;
+    FILE *file;
+
+    mbedtls_pkcs7 pkcs7;
+    mbedtls_x509_crt x509;
+
+    mbedtls_pkcs7_init( &pkcs7 );
+    mbedtls_x509_crt_init( &x509 );
+
+    res = mbedtls_pkcs7_load_file( pkcs7_file, &pkcs7_buf, &buflen );
+    TEST_ASSERT( res == 0 );
+
+    res = mbedtls_pkcs7_parse_der( pkcs7_buf, buflen, &pkcs7 );
+    TEST_ASSERT( res == 0 );
+
+    res = mbedtls_x509_crt_parse_file( &x509, crt );
+    TEST_ASSERT( res == 0 );
+
+    res = stat(filetobesigned, &st);
+    TEST_ASSERT( res == 0 );
+
+    file = fopen( filetobesigned, "r" );
+    TEST_ASSERT( file != NULL );
+
+    datalen = st.st_size;
+    data = ( unsigned char* ) calloc( datalen, sizeof( unsigned char ) );
+    buflen = fread( ( void * )data , sizeof( unsigned char ), datalen, file );
+    TEST_ASSERT( buflen == datalen);
+
+    fclose(file);
+
+    res = mbedtls_pkcs7_signed_data_verify( &pkcs7, &x509, data, datalen );
+    TEST_ASSERT( res != 0 );
+
+exit:
+    mbedtls_x509_crt_free( &x509 );
+    mbedtls_free( data );
+    mbedtls_free( pkcs7_buf );
+    mbedtls_pkcs7_free( &pkcs7 );
+}
+/* END_CASE */
+
+/* BEGIN_CASE */
+void pkcs7_verify_tampered_data( char *pkcs7_file, char *crt, char *filetobesigned )
+{
+    unsigned char *pkcs7_buf = NULL;
+    size_t buflen;
+    unsigned char *data = NULL;
+    struct stat st;
+    size_t datalen;
+    int res;
+    FILE *file;
+
+    mbedtls_pkcs7 pkcs7;
+    mbedtls_x509_crt x509;
+
+    mbedtls_pkcs7_init( &pkcs7 );
+    mbedtls_x509_crt_init( &x509 );
+
+    res = mbedtls_pkcs7_load_file( pkcs7_file, &pkcs7_buf, &buflen );
+    TEST_ASSERT( res == 0 );
+
+    res = mbedtls_pkcs7_parse_der( pkcs7_buf, buflen, &pkcs7 );
+    TEST_ASSERT( res == 0 );
+
+    res = mbedtls_x509_crt_parse_file( &x509, crt );
+    TEST_ASSERT( res == 0 );
+
+    res = stat(filetobesigned, &st);
+    TEST_ASSERT( res == 0 );
+
+    file = fopen( filetobesigned, "r" );
+    TEST_ASSERT( file != NULL );
+
+    datalen = st.st_size;
+    data = ( unsigned char* ) calloc( datalen, sizeof(unsigned char) );
+    buflen = fread( ( void * )data , sizeof( unsigned char ), datalen, file );
+    TEST_ASSERT( buflen == datalen);
+
+    fclose(file);
+
+    res = mbedtls_pkcs7_signed_data_verify( &pkcs7, &x509, data, datalen );
+    TEST_ASSERT( res != 0 );
+
+exit:
+    mbedtls_x509_crt_free( &x509 );
+    mbedtls_pkcs7_free( &pkcs7 );
+    mbedtls_free( data );
+    mbedtls_free( pkcs7_buf );
+
+}
+/* END_CASE */


### PR DESCRIPTION
Hi,

I have the second iteration for PKCS7 PR ready to be pushed to upstream community.
I would like to know if any feedbacks. This is still based on 2.16 version and I will update it to "development" branch before sending upstream.

Few notes:
1. This version supports single signer. However, even for single signer you can have multiple certificates as certificate chain. But it seems it is not easy to differentiate whether the list of certificates are certificate chain or just different certificates. So, I restricted the whole support to single root certificate, and not even certificate chain for the single signer support.  Moreover, we do not need also this support, so it is probably ok to leave it like this as of now rather than spending too much time on figuring out how to support it.

2. As per CRL support, it seems signedData has one more purpose of passing around certificates and CRLs packed as PKCS7 signed data. I couldn't find openssl command line way to specify CRL file while using PKCS7 for signature. It might take it automatically from CA, but not very sure. However, I did find openssl crl2pkcs7 command as specified in the following link. From the following two links, I came to conclusion that CRL works more in combination with certificates to be passed around rather than actually part of PKCS7 signature usecase. 
https://www.mkssoftware.com/docs/man1/openssl_crl2pkcs7.1.asp
And if you see the GnuTLS link (https://www.gnutls.org/manual/html_node/Cryptographic-Message-Syntax-_002f-PKCS7.html) , it specifically says this - _In certain cases the same format is also used to transport lists of certificates and CRLs._   
We do not have such use case for CRL and even from revocation perspective we make use of dbx and not the CRLs atleast as of now. So, again I have strictly made it to not consider CRL. If CRL is added, it will fail while parsing it as signer info.

3. I did realize that I removed the test for CRL but didn't remove it from Makefile. I will fix that before sending upstream.

4. I thought too much about error codes. After switching multiple times between narrowing it further to give exact parse fail or to keep it only a high level fail, I finally chose to keep it high level until I understand how people are having issues in interpreting it. I think it will improve over time.  

Please let me know if any feedbacks by Tuesday EOD.. so that we can try to send second iteration sometime by end of this week.

Thanks & Regards,
     - Nayna